### PR TITLE
Fix issue where previous window callbacks are not saved when setting callbacks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/imgui-glfw/build.gradle.kts
+++ b/imgui-glfw/build.gradle.kts
@@ -49,7 +49,7 @@ kotlin {
             dependencies {
                 implementation(kotlin("stdlib-common"))
                 implementation(project(":imgui"))
-                implementation("com.kgl:kgl-glfw:0.1.9-dev-8")
+                implementation("com.kgl:kgl-glfw:0.1.9-dev-9")
             }
         }
         commonTest {

--- a/imgui-glfw/src/jvmMain/kotlin/com/imgui/impl/ImGuiGLFW.kt
+++ b/imgui-glfw/src/jvmMain/kotlin/com/imgui/impl/ImGuiGLFW.kt
@@ -9,15 +9,15 @@ import org.lwjgl.glfw.GLFW.*
 import org.lwjgl.system.Callback
 import org.lwjgl.system.dyncall.DynCallback.dcbArgPointer
 
-actual class ImGuiGLFW actual constructor(private val window: Window, installCallbacks: Boolean): Closeable {
+actual class ImGuiGLFW actual constructor(private val window: Window, installCallbacks: Boolean) : Closeable {
 	private var time: Double = 0.0
 	private val mouseJustPressed = BooleanArray(5) { false }
 	private val mouseCursors = Array<Cursor?>(ImGuiMouseCursor.values().size) { null }
 
-	private val prevUserCallbackMouseButton: MouseButtonCallback? = null
-	private val prevUserCallbackScroll: ScrollCallback? = null
-	private val prevUserCallbackKey: KeyCallback? = null
-	private val prevUserCallbackChar: CharCallback? = null
+	private val prevUserCallbackMouseButton: MouseButtonCallback?
+	private val prevUserCallbackScroll: ScrollCallback?
+	private val prevUserCallbackKey: KeyCallback?
+	private val prevUserCallbackChar: CharCallback?
 
 	init {
 		val io = ImGui.getIO().ptr
@@ -85,15 +85,16 @@ actual class ImGuiGLFW actual constructor(private val window: Window, installCal
 		mouseCursors[ImGuiMouseCursor.ResizeNWSE.value] = Cursor(Cursor.Standard.Arrow)  // FIXME: GLFW doesn't have this.
 		mouseCursors[ImGuiMouseCursor.Hand.value] = Cursor(Cursor.Standard.Hand)
 
-		// prevUserCallbackMouseButton = null
-		// prevUserCallbackScroll = null
-		// prevUserCallbackKey = null
-		// prevUserCallbackChar = null
 		if (installCallbacks) {
-			window.setMouseButtonCallback(this::mouseButtonCallback)
-			window.setScrollCallback(this::scrollCallback)
-			window.setKeyCallback(this::keyCallback)
-			window.setCharCallback(this::charCallback)
+			prevUserCallbackMouseButton = window.setMouseButtonCallback(this::mouseButtonCallback)
+			prevUserCallbackScroll = window.setScrollCallback(this::scrollCallback)
+			prevUserCallbackKey = window.setKeyCallback(this::keyCallback)
+			prevUserCallbackChar = window.setCharCallback(this::charCallback)
+		} else {
+			prevUserCallbackMouseButton = null
+			prevUserCallbackScroll = null
+			prevUserCallbackKey = null
+			prevUserCallbackChar = null
 		}
 	}
 
@@ -215,6 +216,7 @@ actual class ImGuiGLFW actual constructor(private val window: Window, installCal
 						io.navInputs[navNo.value] = 1.0f
 					}
 				}
+
 				fun mapAnalog(navNo: ImGuiNavInput, axisNo: Int, v0: Float, v1: Float) {
 					var v = if (axesCount > axisNo) axes[axesCount] else v0
 					v = (v - v0) / (v1 - v0)

--- a/imgui-glfw/src/nativeMain/kotlin/com/imgui/impl/ImGuiGLFW.kt
+++ b/imgui-glfw/src/nativeMain/kotlin/com/imgui/impl/ImGuiGLFW.kt
@@ -9,15 +9,15 @@ import io.ktor.utils.io.core.Closeable
 import kotlinx.cinterop.*
 import platform.posix.memset
 
-actual class ImGuiGLFW actual constructor(private val window: Window, installCallbacks: Boolean): Closeable {
+actual class ImGuiGLFW actual constructor(private val window: Window, installCallbacks: Boolean) : Closeable {
 	private var time: Double = 0.0
 	private val mouseJustPressed = BooleanArray(5) { false }
 	private val mouseCursors = Array<Cursor?>(ImGuiMouseCursor.values().size) { null }
 
-	private val prevUserCallbackMouseButton: MouseButtonCallback? = null
-	private val prevUserCallbackScroll: ScrollCallback? = null
-	private val prevUserCallbackKey: KeyCallback? = null
-	private val prevUserCallbackChar: CharCallback? = null
+	private val prevUserCallbackMouseButton: MouseButtonCallback?
+	private val prevUserCallbackScroll: ScrollCallback?
+	private val prevUserCallbackKey: KeyCallback?
+	private val prevUserCallbackChar: CharCallback?
 
 	init {
 		val io = ImGui.getIO().ptr.pointed
@@ -69,15 +69,16 @@ actual class ImGuiGLFW actual constructor(private val window: Window, installCal
 		mouseCursors[ImGuiMouseCursor.ResizeNWSE.value] = Cursor(Cursor.Standard.Arrow)  // FIXME: GLFW doesn't have this.
 		mouseCursors[ImGuiMouseCursor.Hand.value] = Cursor(Cursor.Standard.Hand)
 
-		// prevUserCallbackMouseButton = null
-		// prevUserCallbackScroll = null
-		// prevUserCallbackKey = null
-		// prevUserCallbackChar = null
 		if (installCallbacks) {
-			window.setMouseButtonCallback(this::mouseButtonCallback)
-			window.setScrollCallback(this::scrollCallback)
-			window.setKeyCallback(this::keyCallback)
-			window.setCharCallback(this::charCallback)
+			prevUserCallbackMouseButton = window.setMouseButtonCallback(this::mouseButtonCallback)
+			prevUserCallbackScroll = window.setScrollCallback(this::scrollCallback)
+			prevUserCallbackKey = window.setKeyCallback(this::keyCallback)
+			prevUserCallbackChar = window.setCharCallback(this::charCallback)
+		} else {
+			prevUserCallbackMouseButton = null
+			prevUserCallbackScroll = null
+			prevUserCallbackKey = null
+			prevUserCallbackChar = null
 		}
 	}
 
@@ -200,6 +201,7 @@ actual class ImGuiGLFW actual constructor(private val window: Window, installCal
 						io.NavInputs[navNo.value] = 1.0f
 					}
 				}
+
 				inline fun mapAnalog(navNo: ImGuiNavInput, axisNo: Int, v0: Float, v1: Float) {
 					var v = if (axesCount > axisNo) axes[axesCount] else v0
 					v = (v - v0) / (v1 - v0)

--- a/imgui-opengl/build.gradle.kts
+++ b/imgui-opengl/build.gradle.kts
@@ -49,7 +49,7 @@ kotlin {
             dependencies {
                 implementation(kotlin("stdlib-common"))
                 implementation(project(":imgui"))
-                implementation("com.kgl:kgl-opengl:0.1.9-dev-8")
+                implementation("com.kgl:kgl-opengl:0.1.9-dev-9")
             }
         }
         commonTest {

--- a/samples/build.gradle.kts
+++ b/samples/build.gradle.kts
@@ -47,7 +47,7 @@ kotlin {
                     val lwjglVersion = "3.2.2"
                     val lwjglNatives = "natives-linux"
 
-                    implementation("com.kgl:kgl-glfw:0.1.9-dev-8")
+                    implementation("com.kgl:kgl-glfw:0.1.9-dev-9")
 
                     implementation("org.lwjgl:lwjgl:$lwjglVersion:$lwjglNatives")
                     implementation("org.lwjgl:lwjgl-glfw:$lwjglVersion:$lwjglNatives")
@@ -80,7 +80,7 @@ kotlin {
                     implementation(project(":imgui"))
                     implementation(project(":imgui-glfw"))
                     implementation(project(":imgui-opengl"))
-                    implementation("com.kgl:kgl-glfw-static:0.1.9-dev-8")
+                    implementation("com.kgl:kgl-glfw-static:0.1.9-dev-9")
                 }
             }
         }


### PR DESCRIPTION
Previous window callbacks were not saved when instantiating `ImGuiGLFW`, which borked event handling. This fixes that issue.

PS: For some reason, intellij throws an unsupported operation exception when trying to import the gradle project. Using gradle from the terminal works fine though.