### PR TITLE
Fix minor bug that causes debug message

### DIFF
--- a/imgui-opengl/src/jvmMain/kotlin/com/imgui/impl/ImguiOpenGL3.kt
+++ b/imgui-opengl/src/jvmMain/kotlin/com/imgui/impl/ImguiOpenGL3.kt
@@ -140,7 +140,7 @@ actual class ImguiOpenGL3 actual constructor(
 
 		// Restore modified GL state
 		GL30.glBindTexture(GL30.GL_TEXTURE_2D, lastTexture)
-		GL30.glBindTexture(GL30.GL_ARRAY_BUFFER, lastArrayBuffer)
+		GL30.glBindBuffer(GL30.GL_ARRAY_BUFFER, lastArrayBuffer)
 		if (useVertexArray) GL30.glBindVertexArray(lastVertexArray)
 	}
 

--- a/imgui-opengl/src/nativeMain/kotlin/com/imgui/impl/ImguiOpenGL3.kt
+++ b/imgui-opengl/src/nativeMain/kotlin/com/imgui/impl/ImguiOpenGL3.kt
@@ -159,7 +159,7 @@ actual class ImguiOpenGL3 actual constructor(
 
 		// Restore modified GL state
 		glBindTexture(GL_TEXTURE_2D, lastTexture.toUInt())
-		glBindTexture(GL_ARRAY_BUFFER, lastArrayBuffer.toUInt())
+		glBindBuffer(GL_ARRAY_BUFFER, lastArrayBuffer.toUInt())
 		if (useVertexArray) glBindVertexArray(lastVertexArray.toUInt())
 	}
 


### PR DESCRIPTION
glBindTexture doesn't allow binding to a GL_ARRAY_BUFFER target and results in a GL_INVALID_ENUM error. It didn't crash the app in my use case, but did spam the console with a needless error.