### PR TITLE
Misc cleanup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,2 @@
 gradlew      text eol=lf
 gradlew.bat  text eol=crlf
-
-cimgui/src/jvmMain/java/*         linguist-generated=true
-cimgui/src/jvmMain/cpp/*          linguist-generated=true
-imgui/src/commonMain/generated/*  linguist-generated=true
-imgui/src/jvmMain/generated/*     linguist-generated=true
-imgui/src/nativeMain/generated/*  linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,3 @@ build
 .idea/
 *.iml
 imgui.ini
-cimgui/src/jvmMain/java
-cimgui/src/jvmMain/cpp
-imgui/src/commonMain/generated
-imgui/src/jvmMain/generated
-imgui/src/nativeMain/generated

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ dependencies {
 }
 ```
 
-After `kotlin-imgui` is setup in your application, you can use it from _anywhere_ in your program loop:
+After `kotlin-imgui` is set up in your application, you can use it from _anywhere_ in your program loop:
 ```kotlin
 with(ImGui) {
     text("Hello, world ${123}")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ subprojects {
 	plugins.withId("org.jetbrains.kotlin.multiplatform") {
 		configure<KotlinMultiplatformExtension> {
 			sourceSets.all {
-				languageSettings.run {
+				languageSettings.apply {
 					enableLanguageFeature("InlineClasses")
 					useExperimentalAnnotation("kotlin.RequiresOptIn")
 					useExperimentalAnnotation("kotlin.ExperimentalUnsignedTypes")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.*
+
 plugins {
 	`java-gradle-plugin`
 	kotlin("jvm") version "1.3.72"
@@ -6,13 +8,10 @@ plugins {
 
 repositories {
 	jcenter()
-	mavenCentral()
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-	kotlinOptions {
-		jvmTarget = "1.8"
-	}
+tasks.withType<KotlinCompile> {
+	kotlinOptions.jvmTarget = "1.8"
 }
 
 dependencies {

--- a/buildSrc/src/main/kotlin/GenerateImGuiTask.kt
+++ b/buildSrc/src/main/kotlin/GenerateImGuiTask.kt
@@ -1,33 +1,24 @@
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
-import kotlinx.serialization.ImplicitReflectionSerializer
-import kotlinx.serialization.UnstableDefault
-import kotlinx.serialization.builtins.MapSerializer
-import kotlinx.serialization.builtins.list
-import kotlinx.serialization.builtins.serializer
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonConfiguration
-import kotlinx.serialization.json.JsonLiteral
-import kotlinx.serialization.json.JsonObject
-import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.TaskAction
-import java.nio.file.Paths
+import kotlinx.serialization.builtins.*
+import kotlinx.serialization.json.*
+import org.gradle.api.*
+import org.gradle.api.file.*
+import org.gradle.api.tasks.*
 
+@Suppress("UnstableApiUsage")
 open class GenerateImGuiTask : DefaultTask() {
 	@InputDirectory
-	val inputDir = project.objects.directoryProperty()
+	val inputDir: DirectoryProperty = project.objects.directoryProperty()
 
 	@OutputDirectory
-	val commonDir = project.objects.directoryProperty()
+	val commonDir: DirectoryProperty = project.objects.directoryProperty()
 
 	@OutputDirectory
-	val jvmDir = project.objects.directoryProperty()
+	val jvmDir: DirectoryProperty = project.objects.directoryProperty()
 
 	@OutputDirectory
-	val nativeDir = project.objects.directoryProperty()
+	val nativeDir: DirectoryProperty = project.objects.directoryProperty()
 
 	@TaskAction
 	fun generate() {
@@ -38,7 +29,8 @@ open class GenerateImGuiTask : DefaultTask() {
 		val definitionsStr = inputDir.file("definitions.json").get().asFile.readText()
 		val structsAndEnumsStr = inputDir.file("structs_and_enums.json").get().asFile.readText()
 
-		val definitions = CImGuiJson.parse(MapSerializer(String.serializer(), Definition.serializer().list), definitionsStr)
+		val definitions =
+			CImGuiJson.parse(MapSerializer(String.serializer(), Definition.serializer().list), definitionsStr)
 		val (enums, structs) = CImGuiJson.parse(StructsAndEnums.serializer(), structsAndEnumsStr)
 
 		val enumBitMasks = enums.entries
@@ -65,7 +57,11 @@ open class GenerateImGuiTask : DefaultTask() {
 				"unsigned int" -> ReturnValue(U_INT, CodeBlock.of(".toUInt()"))
 				"unsigned short" -> ReturnValue(U_SHORT, CodeBlock.of(".toUShort()"))
 				"const char*" -> ReturnValue(STRING, CodeBlock.of(".%M()", TO_KSTRING), CodeBlock.of(""))
-				"const ImWchar*" -> ReturnValue(STRING, CodeBlock.of(".%M()", TO_KSTRING), CodeBlock.of(".toUTF16String()"))
+				"const ImWchar*" -> ReturnValue(
+					STRING,
+					CodeBlock.of(".%M()", TO_KSTRING),
+					CodeBlock.of(".toUTF16String()")
+				)
 				"ImVec2" -> ReturnValue(VEC2, CodeBlock.of(".fromCValue()"), jvmVecConverter)
 				"ImVec4" -> ReturnValue(VEC4, CodeBlock.of(".fromCValue()"), jvmVecConverter)
 				"ImWchar" -> ReturnValue(CHAR, CodeBlock.of(".toShort().toChar()"))
@@ -113,9 +109,7 @@ open class GenerateImGuiTask : DefaultTask() {
 
 			val nullOp = if (isNullable) {
 				if (assertIfNull) "!!" else "?"
-			} else {
-				""
-			}
+			} else ""
 
 			if (type == "unsigned int") return FuncArg(U_INT, jvmConv = CodeBlock.of(".toLong()"))
 			if (type == "ImU32") return FuncArg(U_INT, jvmConv = CodeBlock.of(".toLong()"))
@@ -247,15 +241,15 @@ open class GenerateImGuiTask : DefaultTask() {
 				commonEnum.addEnumConstant(enumValueNameKt)
 				nativeEnum.addEnumConstant(
 					enumValueNameKt, TypeSpec.anonymousClassBuilder()
-					.addSuperclassConstructorParameter(
-						CodeBlock.of("%M.%M()", MemberName("cimgui.internal", enumValue.name), CONVERT)
-					)
-					.build()
+						.addSuperclassConstructorParameter(
+							CodeBlock.of("%M.%M()", MemberName("cimgui.internal", enumValue.name), CONVERT)
+						)
+						.build()
 				)
 				jvmEnum.addEnumConstant(
 					enumValueNameKt, TypeSpec.anonymousClassBuilder()
-					.addSuperclassConstructorParameter("%M", MemberName(enumJvmClass, enumValue.name))
-					.build()
+						.addSuperclassConstructorParameter("%M", MemberName(enumJvmClass, enumValue.name))
+						.build()
 				)
 				lookUpTable.addStatement("%N -> %N", enumValue.name, enumValueNameKt)
 			}
@@ -299,7 +293,11 @@ open class GenerateImGuiTask : DefaultTask() {
 					nativeCompanionObject.addProperty(
 						PropertySpec.builder(propName, flagKt)
 							.initializer(
-								CodeBlock.of("%T(%M.toInt(), cachedInfo)", FLAG, MemberName("cimgui.internal", constName))
+								CodeBlock.of(
+									"%T(%M.toInt(), cachedInfo)",
+									FLAG,
+									MemberName("cimgui.internal", constName)
+								)
 							)
 							.addModifiers(KModifier.ACTUAL)
 							.build()
@@ -501,7 +499,11 @@ open class GenerateImGuiTask : DefaultTask() {
 						val isNullable = defaultValue == "((void*)0)" ||
 							(isBitMask && (defaultValue == "0" || defaultValue?.endsWith("_None") == true))
 
-						val (type, nativeConv, jvmConv, propToPtr) = convertKotlinTypeToNative(arg.type, isNullable, false)
+						val (type, nativeConv, jvmConv, propToPtr) = convertKotlinTypeToNative(
+							arg.type,
+							isNullable,
+							false
+						)
 						val actualType = arg.type.removePrefix("const ")
 						val passesStructByValue = actualType == "ImVec4" || actualType == "ImVec2"
 						val isUnicodeStr = arg.type == "const ImWchar*"
@@ -611,7 +613,10 @@ open class GenerateImGuiTask : DefaultTask() {
 					add("\n")
 					indent()
 				}
-				add("%M(", MemberName(cimguiClass, if (returnsStructByValue) "${cImGuiFunName}_nonUDT" else cImGuiFunName))
+				add(
+					"%M(",
+					MemberName(cimguiClass, if (returnsStructByValue) "${cImGuiFunName}_nonUDT" else cImGuiFunName)
+				)
 				if (returnsStructByValue) {
 					add("returnVal")
 					if (jvmArguments.isNotEmpty()) add(", ")
@@ -913,7 +918,11 @@ open class GenerateImGuiTask : DefaultTask() {
 								nativeSetter.addStatement("ptr.%M.%N.%M(value)", POINTED, member.name, fromKValue)
 								jvmSetter.addStatement("ptr.%N.%M(value)", memberNameKt, fromKValue)
 							} else {
-								val (_, nativeInConv, jvmInConv) = convertKotlinTypeToNative(member.type, canBeNull, false)
+								val (_, nativeInConv, jvmInConv) = convertKotlinTypeToNative(
+									member.type,
+									canBeNull,
+									false
+								)
 								nativeSetter.addCode("ptr.%M.%N = value", POINTED, member.name)
 								nativeSetter.addCode(nativeInConv)
 								nativeSetter.addCode("\n")

--- a/cimgui/build.gradle.kts
+++ b/cimgui/build.gradle.kts
@@ -21,7 +21,7 @@ val toolChainFolder = when (HostManager.host) {
 	KonanTarget.LINUX_X64 -> "clang-llvm-8.0.0-linux-x86-64"
 	KonanTarget.MACOS_X64 -> "clang-llvm-apple-8.0.0-darwin-macos"
 	KonanTarget.MINGW_X64 -> "msys2-mingw-w64-x86_64-clang-llvm-lld-compiler_rt-8.0.1"
-	else -> TODO()
+	else -> error("unknown host")
 }
 val llvmBinFolder = konanDeps.resolve(toolChainFolder).resolve("bin")
 val androidSysRootParent = konanDeps.resolve("target-sysroot-1-android_ndk").resolve("android-21")

--- a/imgui-glfw/build.gradle.kts
+++ b/imgui-glfw/build.gradle.kts
@@ -10,40 +10,15 @@ val useSingleTarget: Boolean by rootProject.extra
 val kglVersion: String by rootProject.extra
 
 kotlin {
-	if (!useSingleTarget || HostManager.hostIsLinux) linuxX64()
-	if (!useSingleTarget || HostManager.hostIsMingw) mingwX64()
-	if (!useSingleTarget || HostManager.hostIsMac) macosX64()
-
 	jvm {
-		compilations {
-			"main" {
-				dependencies {
-					api(kotlin("stdlib-jdk8"))
-					compileOnly(project(":cimgui", "jvmDefault"))
-				}
-			}
-			"test" {
-				dependencies {
-					implementation(kotlin("test"))
-					implementation(kotlin("test-junit"))
-				}
-			}
+		compilations.all {
+			kotlinOptions.jvmTarget = "1.8"
 		}
 	}
 
-	targets.withType<KotlinNativeTarget> {
-		compilations {
-			"main" {
-				defaultSourceSet {
-					kotlin.srcDir("src/nativeMain/kotlin")
-				}
-
-				dependencies {
-					implementation(project(":cimgui"))
-				}
-			}
-		}
-	}
+	if (!useSingleTarget || HostManager.hostIsLinux) linuxX64()
+	if (!useSingleTarget || HostManager.hostIsMac) macosX64()
+	if (!useSingleTarget || HostManager.hostIsMingw) mingwX64()
 
 	sourceSets {
 		commonMain {
@@ -53,10 +28,38 @@ kotlin {
 				implementation("com.kgl:kgl-glfw:$kglVersion")
 			}
 		}
+
 		commonTest {
 			dependencies {
 				implementation(kotlin("test-common"))
 				implementation(kotlin("test-annotations-common"))
+			}
+		}
+
+		named("jvmMain") {
+			dependencies {
+				compileOnly(project(":cimgui", "jvmDefault"))
+			}
+		}
+
+		named("jvmTest") {
+			dependencies {
+				implementation(kotlin("test-junit"))
+			}
+		}
+
+		targets.withType<KotlinNativeTarget> {
+			named("${name}Main") {
+				kotlin.srcDir("src/nativeMain/kotlin")
+				resources.srcDir("src/nativeMain/resources")
+				dependencies {
+					implementation(project(":cimgui"))
+				}
+			}
+
+			named("${name}Test") {
+				kotlin.srcDir("src/nativeTest/kotlin")
+				resources.srcDir("src/nativeTest/resources")
 			}
 		}
 	}

--- a/imgui-opengl/build.gradle.kts
+++ b/imgui-opengl/build.gradle.kts
@@ -10,40 +10,15 @@ val useSingleTarget: Boolean by rootProject.extra
 val kglVersion: String by rootProject.extra
 
 kotlin {
-	if (!useSingleTarget || HostManager.hostIsLinux) linuxX64()
-	if (!useSingleTarget || HostManager.hostIsMingw) mingwX64()
-	if (!useSingleTarget || HostManager.hostIsMac) macosX64()
-
 	jvm {
-		compilations {
-			"main" {
-				dependencies {
-					api(kotlin("stdlib-jdk8"))
-					compileOnly(project(":cimgui", "jvmDefault"))
-				}
-			}
-			"test" {
-				dependencies {
-					implementation(kotlin("test"))
-					implementation(kotlin("test-junit"))
-				}
-			}
+		compilations.all {
+			kotlinOptions.jvmTarget = "1.8"
 		}
 	}
 
-	targets.withType<KotlinNativeTarget> {
-		compilations {
-			"main" {
-				defaultSourceSet {
-					kotlin.srcDir("src/nativeMain/kotlin")
-				}
-
-				dependencies {
-					implementation(project(":cimgui"))
-				}
-			}
-		}
-	}
+	if (!useSingleTarget || HostManager.hostIsLinux) linuxX64()
+	if (!useSingleTarget || HostManager.hostIsMac) macosX64()
+	if (!useSingleTarget || HostManager.hostIsMingw) mingwX64()
 
 	sourceSets {
 		commonMain {
@@ -53,10 +28,38 @@ kotlin {
 				implementation("com.kgl:kgl-opengl:$kglVersion")
 			}
 		}
+
 		commonTest {
 			dependencies {
 				implementation(kotlin("test-common"))
 				implementation(kotlin("test-annotations-common"))
+			}
+		}
+
+		named("jvmMain") {
+			dependencies {
+				compileOnly(project(":cimgui", "jvmDefault"))
+			}
+		}
+
+		named("jvmTest") {
+			dependencies {
+				implementation(kotlin("test-junit"))
+			}
+		}
+
+		targets.withType<KotlinNativeTarget> {
+			named("${name}Main") {
+				kotlin.srcDir("src/nativeMain/kotlin")
+				resources.srcDir("src/nativeMain/resources")
+				dependencies {
+					implementation(project(":cimgui"))
+				}
+			}
+
+			named("${name}Test") {
+				kotlin.srcDir("src/nativeTest/kotlin")
+				resources.srcDir("src/nativeTest/resources")
 			}
 		}
 	}

--- a/imgui-opengl/src/jvmMain/kotlin/com/imgui/impl/ImGuiOpenGL3.kt
+++ b/imgui-opengl/src/jvmMain/kotlin/com/imgui/impl/ImGuiOpenGL3.kt
@@ -304,7 +304,7 @@ actual constructor(
 						setupRenderState(drawData, fbWidth, fbHeight, vertexArrayObject)
 					} else {
 						// pcmd.userCallback!!(cmdList, pcmd)
-						TODO()
+						TODO("pcmd.userCallback (swig function pointer call?)")
 					}
 				} else {
 					// Project scissor/clipping rectangles into framebuffer space

--- a/imgui/build.gradle.kts
+++ b/imgui/build.gradle.kts
@@ -7,14 +7,13 @@ plugins {
 }
 
 val useSingleTarget: Boolean by rootProject.extra
-
 val imGuiVersion: String by rootProject.extra
 
 val generateImGui by tasks.registering(GenerateImGuiTask::class) {
-	inputDir.set(project(":cimgui").buildDir.resolve("downloads/cimgui-${imGuiVersion}/generator/output"))
-	commonDir.set(file("src/commonMain/generated"))
-	jvmDir.set(file("src/jvmMain/generated"))
-	nativeDir.set(file("src/nativeMain/generated"))
+	inputDir.set(project(":cimgui").buildDir.resolve("downloads/cimgui-$imGuiVersion/generator/output"))
+	commonDir.set(buildDir.resolve("generated-src/common"))
+	jvmDir.set(buildDir.resolve("generated-src/jvm"))
+	nativeDir.set(buildDir.resolve("generated-src/native"))
 }
 
 kotlin {
@@ -27,7 +26,7 @@ kotlin {
 			"main" {
 				compileKotlinTask.dependsOn(generateImGui)
 				defaultSourceSet {
-					kotlin.srcDir("src/jvmMain/generated")
+					kotlin.srcDir(generateImGui.map { it.jvmDir })
 				}
 				dependencies {
 					api(kotlin("stdlib-jdk8"))
@@ -52,7 +51,7 @@ kotlin {
 			"main" {
 				compileKotlinTask.dependsOn(generateImGui)
 				defaultSourceSet {
-					kotlin.srcDir("src/nativeMain/generated")
+					kotlin.srcDir(generateImGui.map { it.nativeDir })
 					kotlin.srcDir("src/nativeMain/kotlin")
 				}
 
@@ -70,7 +69,7 @@ kotlin {
 
 	sourceSets {
 		commonMain {
-			kotlin.srcDir("src/commonMain/generated")
+			kotlin.srcDir(generateImGui.map { it.commonDir })
 			dependencies {
 				implementation(kotlin("stdlib-common"))
 			}

--- a/imgui/src/commonTest/kotlin/Utils.kt
+++ b/imgui/src/commonTest/kotlin/Utils.kt
@@ -1,4 +1,3 @@
-import com.imgui.ImFont
-import com.imgui.ImFontAtlas
+import com.imgui.*
 
 expect fun ImFontAtlas.getTexDataAsRGBA32()

--- a/imgui/src/jvmMain/kotlin/com/imgui/Utils.kt
+++ b/imgui/src/jvmMain/kotlin/com/imgui/Utils.kt
@@ -32,7 +32,7 @@ internal fun loadCImGuiNativeLibs() {
 			simpleOsName = "windows"
 			extName = "dll"
 		}
-		else -> TODO("OS '$osName' not support by cimgui")
+		else -> error("OS '$osName' not support by cimgui")
 	}
 	val simpleOsArch = when (osArch) {
 		"amd64", "x86_64" -> "x64"


### PR DESCRIPTION
- move generation output into the build folders
- clean up and optimize (remove unneeded bits) gradle build files
- replace `TODO()` with `error()` where appropriate